### PR TITLE
Redesigning active tool list display

### DIFF
--- a/app/src/streamlit_app.py
+++ b/app/src/streamlit_app.py
@@ -43,12 +43,19 @@ with st.sidebar:
     st.header("MCP Servers")
     toolgroup_selection = st.pills(label="Available Servers",options=tool_groups_list, selection_mode="multi",on_change=reset_agent)    
     
-    active_tool_list = []
+    grouped_tools = {}
+    total_tools = 0
     for toolgroup_id in toolgroup_selection:
-        active_tool_list.extend([f"{toolgroup_id[5:]}:{t.identifier}" for t in client.tools.list(toolgroup_id=toolgroup_id)])
-    
-    st.markdown(f"Active Tools: 🛠 {len(active_tool_list)}")
-    st.json(active_tool_list)
+        tools = client.tools.list(toolgroup_id=toolgroup_id)
+        grouped_tools[toolgroup_id] = [tool.identifier for tool in tools]
+        total_tools += len(tools)
+
+    st.markdown(f"Active Tools: 🛠 {total_tools}")
+
+    for group_id, tools in grouped_tools.items():
+        with st.expander(f"🔧 Tools from `{group_id}`"):
+            for idx, tool in enumerate(tools, start=1):
+                st.markdown(f"{idx}. `{group_id}:{tool}`")
 
     st.text_input(label="Install New Server", placeholder="MCP Server")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Redesigned layout for the Active Tools section in the Streamlit app.
Instead of showing tools in a flat JSON list, tools are now:
- Grouped under their corresponding MCP servers using st.expander
- Displayed with numbered labels and fully qualified names like mcp::openshift:pods_list

This improves readability and makes it easier to trace tool provenance when multiple MCP servers are selected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally using python -m streamlit run streamlit_app.py
- Environment: macOS, Python 3.11
- Selected multiple MCP servers from the sidebar.
![Screenshot 2025-04-04 at 12 28 55 PM](https://github.com/user-attachments/assets/c3ebf018-0eb5-4497-9127-e1e0e0471912)

- Verified that tools are displayed correctly under each server

